### PR TITLE
Update endpoint.go

### DIFF
--- a/internal/service/dms/endpoint.go
+++ b/internal/service/dms/endpoint.go
@@ -471,8 +471,7 @@ func ResourceEndpoint() *schema.Resource {
 						},
 						"compression_type": {
 							Type:         schema.TypeString,
-							Optional:     true,
-							Default:      s3SettingsCompressionTypeNone,
+							Optional:     true,							
 							ValidateFunc: validation.StringInSlice(s3SettingsCompressionType_Values(), false),
 						},
 						"csv_delimiter": {


### PR DESCRIPTION
### Description
Remove default value of "NONE" for dms endpoint S3 compression. Source s3 endpoints no longer support compressionType. When not set, the aws default is no compression. This allows the target to continue to define a compressionType while source endpoints can get around the bug by not setting a value for this property. The only other work around is change source endpoint to target deploy and the change it back to source, which is not ideal.

### Relations
Relates #27852

### References
#27283

